### PR TITLE
upscale->dilation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,5 +1,5 @@
 name = "KnetLayers"
-uuid = "80bfaf46-ad8a-11e8-19eb-a135e382307b"
+uuid = "e09e3f5a-3c2e-516c-a806-60ae64389a85"
 authors = ["ekinakyurek <akyurekekin@gmail.com>"]
 version = "0.1.0"
 

--- a/src/cnn.jl
+++ b/src/cnn.jl
@@ -78,8 +78,8 @@ function Filtering{T}(;height::Integer, width::Integer, inout::Pair=1=>1,
     Filtering{T}(w, b, activation; opts...)
 end
 
-Filtering{T}(w, b, activation; stride=1, padding=0, mode=0, upscale=1, alpha=1) where T <: Function =
-    Filtering{T}(w, b, activation, (stride=stride, upscale=upscale, mode=mode, alpha=alpha, padding=padding))
+Filtering{T}(w, b, activation; stride=1, padding=0, mode=0, dilation=1, alpha=1) where T <: Function =
+    Filtering{T}(w, b, activation, (stride=stride, dilation=dilation, mode=mode, alpha=alpha, padding=padding))
 
 (m::Filtering{typeof(conv4)})(x) =
      postConv(m, conv4(m.weight, make4D(x); m.options...), ndims(x))
@@ -113,7 +113,7 @@ or an tuple with entries for each spatial dimension.
 * `bias=zeros`: bias initialization distribution
 * `padding=0`: the number of extra zeros implicitly concatenated at the start and at the end of each dimension.
 * `stride=1`: the number of elements to slide to reach the next filtering window.
-* `upscale=1`: upscale factor for each dimension.
+* `dilation=1`: dilation factor for each dimension.
 * `mode=0`: 0 for convolution and 1 for cross-correlation.
 * `alpha=1`: can be used to scale the result.
 * `handle`: handle to a previously created cuDNN context. Defaults to a Knet allocated handle.
@@ -148,7 +148,7 @@ or an tuple with entries for each spatial dimension.
 * `bias=zeros`: bias initialization distribution
 * `padding=0`: the number of extra zeros implicitly concatenated at the start and at the end of each dimension.
 * `stride=1`: the number of elements to slide to reach the next filtering window.
-* `upscale=1`: upscale factor for each dimension.
+* `dilation=1`: dilation factor for each dimension.
 * `mode=0`: 0 for convolution and 1 for cross-correlation.
 * `alpha=1`: can be used to scale the result.
 * `handle`: handle to a previously created cuDNN context. Defaults to a Knet allocated handle.


### PR DESCRIPTION
With this change tests pass with latest Knet versions.
See https://github.com/denizyuret/Knet.jl/issues/322 and https://github.com/denizyuret/Knet.jl/issues/434 for justifications for this change. CuDNN docs also call this dilation now, it is for dilated convolutions, upscale never worked and was never used.